### PR TITLE
fix: alpine builds for Node.js 24

### DIFF
--- a/3.2/24/alpine/Dockerfile
+++ b/3.2/24/alpine/Dockerfile
@@ -4,10 +4,8 @@ LABEL maintainer="Tim Prüssing <github@timbrust.de>"
 ARG REFRESHED_AT
 ENV REFRESHED_AT=$REFRESHED_AT
 
-RUN echo @edge https://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories \
-  && echo @edge https://dl-cdn.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories \
-  apk -U upgrade \
+RUN apk -U upgrade \
   && apk add --no-cache \
-    nodejs-current@edge \
+    nodejs \
     npm \
     yarn

--- a/3.3/24/alpine/Dockerfile
+++ b/3.3/24/alpine/Dockerfile
@@ -4,10 +4,8 @@ LABEL maintainer="Tim Prüssing <github@timbrust.de>"
 ARG REFRESHED_AT
 ENV REFRESHED_AT=$REFRESHED_AT
 
-RUN echo @edge https://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories \
-  && echo @edge https://dl-cdn.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories \
-  apk -U upgrade \
+RUN apk -U upgrade \
   && apk add --no-cache \
-    nodejs-current@edge \
+    nodejs \
     npm \
     yarn

--- a/3.4/24/alpine/Dockerfile
+++ b/3.4/24/alpine/Dockerfile
@@ -4,10 +4,8 @@ LABEL maintainer="Tim Prüssing <github@timbrust.de>"
 ARG REFRESHED_AT
 ENV REFRESHED_AT=$REFRESHED_AT
 
-RUN echo @edge https://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories \
-  && echo @edge https://dl-cdn.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories \
-  apk -U upgrade \
+RUN apk -U upgrade \
   && apk add --no-cache \
-    nodejs-current@edge \
+    nodejs \
     npm \
     yarn

--- a/4.0/24/alpine/Dockerfile
+++ b/4.0/24/alpine/Dockerfile
@@ -4,10 +4,8 @@ LABEL maintainer="Tim Prüssing <github@timbrust.de>"
 ARG REFRESHED_AT
 ENV REFRESHED_AT=$REFRESHED_AT
 
-RUN echo @edge https://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories \
-  && echo @edge https://dl-cdn.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories \
-  apk -U upgrade \
+RUN apk -U upgrade \
   && apk add --no-cache \
-    nodejs-current@edge \
+    nodejs \
     npm \
     yarn


### PR DESCRIPTION
This pull request updates the Alpine-based Dockerfiles for several versions to simplify Node.js installation and improve stability. The main change is switching from using the `nodejs-current@edge` package (from the Alpine Edge repositories) to the stable `nodejs` package from the main repository, and removing the addition of Edge repositories.

Dependency management and stability improvements:

* Updated the installation process in `3.2/24/alpine/Dockerfile`, `3.3/24/alpine/Dockerfile`, `3.4/24/alpine/Dockerfile`, and `4.0/24/alpine/Dockerfile` to use the stable `nodejs` package instead of `nodejs-current@edge`, and removed the inclusion of Edge repositories. This change reduces the risk of instability from using Edge packages and ensures more predictable builds. [[1]](diffhunk://#diff-b3418710ae33435573e0f839509c79ea515e3bd7630c29cd0d7969bfe65febd0L7-R9) [[2]](diffhunk://#diff-5700865bdb7c280a15fa36f1bd3459e77991503c2ba06d6acbe0faa6e1ed7b78L7-R9) [[3]](diffhunk://#diff-b2fdd6925df40cf7e2874cc3f2888a63436222802ef839229136ddd131f1497fL7-R9) [[4]](diffhunk://#diff-eb480bfb61fb5f9d40b37abbf2e551700adf57cf9e7a00999491d12eaf4bfa12L7-R9)